### PR TITLE
Update OngoingCallThreadLocalContext.mm

### DIFF
--- a/submodules/TgVoip/Sources/OngoingCallThreadLocalContext.mm
+++ b/submodules/TgVoip/Sources/OngoingCallThreadLocalContext.mm
@@ -272,7 +272,7 @@ static void (*InternalVoipLoggingFunction)(NSString *) = NULL;
             .enableAGC = true,
             .enableCallUpgrade = false,
             .logPath = logPath.length == 0 ? "" : std::string(logPath.UTF8String),
-            .maxApiLayer = [OngoingCallThreadLocalContext maxLayer]
+            .maxApiLayer = maxLayer
         };
         
         std::vector<uint8_t> encryptionKeyValue;


### PR DESCRIPTION
Fix issue that prevents calling TgVoip calls with api layers lower than current libs max layer.